### PR TITLE
Replaces the "openid profile" scope

### DIFF
--- a/examples/basic-mvc-sample/BasicMvcSample/Views/Account/Login.cshtml
+++ b/examples/basic-mvc-sample/BasicMvcSample/Views/Account/Login.cshtml
@@ -21,7 +21,7 @@
       , callbackURL: window.location.origin + '/signin-auth0'
       , responseType: 'code'
       , authParams: {
-          scope: 'openid profile',
+          scope: 'openid name email',
           state: 'xsrf=' + xsrf + '&ru=' + '@ViewBag.ReturnUrl'
       }
     });


### PR DESCRIPTION
The recommended use of scope replaces ‘openid profile’ with ‘openid
name email’.