### PR TITLE
Outdated README.md

### DIFF
--- a/examples/basic-mvc-sample/README.md
+++ b/examples/basic-mvc-sample/README.md
@@ -2,7 +2,7 @@
 This is the seed project you need to use if you're going to create an ASP.NET application using OWIN.
 
 #Running the example
-In order to run the example you need to have Visual Studio 2013 installed.
+In order to run the example you need to have Visual Studio installed.
 
 You also need to set the ClientSecret, ClientId and Domain of your Auth0 app in the web.config file. To do that just look for the following keys and enter the right content:
 ```CSharp

--- a/examples/basic-mvc-sample/README.md
+++ b/examples/basic-mvc-sample/README.md
@@ -2,7 +2,7 @@
 This is the seed project you need to use if you're going to create an ASP.NET application using OWIN.
 
 #Running the example
-In order to run the example you need to have Visual Studio installed.
+In order to run the example you need to have Visual Studio 2013/2015 installed.
 
 You also need to set the ClientSecret, ClientId and Domain of your Auth0 app in the web.config file. To do that just look for the following keys and enter the right content:
 ```CSharp


### PR DESCRIPTION
I would like to fix it tested with both Visual Studio 2013 and Visual Studio 2015  , so you can use both of them or any of them
The easy fix would be to just delete the year and leave it as Visual Studio "You need to have Visual Studio installed"