### PR TITLE
Warning on Katana cookie issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ In this repository we've also included different Owin samples, using the Auth0 A
  - [ASP.NET 4 - MVC seed project with Auth0-ASPNET-OWIN](https://github.com/auth0/auth0-aspnet-owin/tree/master/examples/basic-mvc-sample)
  - [ASP.NET 4 - Web API sample with Bearer Tokens](https://github.com/auth0/auth0-aspnet-owin/tree/master/examples/WebApi)
 
- ## Issue Reporting
+## Issue Reporting
 
- If you have found a bug or if you have a feature request, please report them at this repository issues section. Please do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://auth0.com/whitehat) details the procedure for disclosing security issues.
+If you have found a bug or if you have a feature request, please report them at this repository issues section. Please do not report security vulnerabilities on the public GitHub issue tracker. The [Responsible Disclosure Program](https://auth0.com/whitehat) details the procedure for disclosing security issues.
 
- ## Author
+## Author
 
- [Auth0](auth0.com)
+[Auth0](auth0.com)
 
- ## License
+## License
 
- This project is licensed under the MIT license. See the [LICENSE](LICENSE) file for more info.
+This project is licensed under the MIT license. See the [LICENSE](LICENSE) file for more info.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,28 @@ Install-Package Auth0-ASPNET-Owin-Libs
 
 [Please see this NuGet's README.](nuget/README.txt)
 
+## Katana issue with cookies
+
+There is an bug with the Katana OWIN implementation (Microsoft.Owin.Host.SystemWeb), that causes cookies set in an OWIN middleware to sometimes disappear. This results in the authentication flow not being able to complete. The sympton in this case is that the `AuthenticationManager.GetExternalLoginInfo()` or similar calls that depend on a cookie being set will fail. 
+
+The issue is described [here](https://katanaproject.codeplex.com/workitem/197), and the current workaround is installing the [Kentor.OwinCookieSaver package](https://www.nuget.org/packages/Kentor.OwinCookieSaver/). 
+
+First install the package:
+
+```
+Install-Package Kentor.OwinCookieSaver
+```
+
+and then configure the middleware. The `Kentor.OwinCookieSaver` middleware should be added before other cookie handling middleware:
+
+```
+app.UseKentorOwinCookieSaver();
+
+app.UseCookieAuthentication(new CookieAuthenticationOptions(...));
+```
+
+Further details are provided at https://github.com/KentorIT/owin-cookie-saver.
+
 ## Examples
 
 In this repository we've also included different Owin samples, using the Auth0 Authentication Handler or standards based (Bearer token, OpenID Connect, ...) handlers.


### PR DESCRIPTION
Added a warning and workaround on the `readme.md` for an issue with Katana that looses the authentication cookie on some occasions.
